### PR TITLE
Add support for br-input-validation-error.

### DIFF
--- a/input-directive.js
+++ b/input-directive.js
@@ -16,7 +16,7 @@ ng-multi-transclude, transcluded content was assumed to be help content. In
 order to detect a deprecated use of `br-input`, we check the transcluded
 content below to see if it lacks any ng-multi-transclude IDs. Any supported
 IDs must be listed here in the array below so this will work properly. */
-var TRANSCLUDE_SELECTOR = ['help'].map(function(name) {
+var TRANSCLUDE_SELECTOR = ['help','validation-error'].map(function(name) {
   return '[name="br-input-' + name + '"]';
 }).join(',');
 
@@ -83,10 +83,15 @@ function factory() {
           </span> \
         </div> \
         <div ng-if="_brInput.options.help" ng-show="_brInput.help.show" \
-          class="{{_brInput.options.columns.help}} help-block \
+          class="{{_brInput.options.columns.help}}" help-block \
             br-fadein br-fadeout" ng-multi-transclude-controller> \
           <div ng-if="_brInput.legacy" ng-transclude></div> \
           <div ng-multi-transclude="br-input-help"></div> \
+        </div> \
+        <div ng-multi-transclude-controller \
+          class="{{_brInput.options.columns.help}}"> \
+          <div ng-multi-transclude="br-input-validation-error"> \
+          </div> \
         </div> \
       </div>',
     compile: Compile

--- a/input-directive.js
+++ b/input-directive.js
@@ -83,7 +83,7 @@ function factory() {
           </span> \
         </div> \
         <div ng-if="_brInput.options.help" ng-show="_brInput.help.show" \
-          class="{{_brInput.options.columns.help}}" help-block \
+          class="{{_brInput.options.columns.help}} help-block \
             br-fadein br-fadeout" ng-multi-transclude-controller> \
           <div ng-if="_brInput.legacy" ng-transclude></div> \
           <div ng-multi-transclude="br-input-help"></div> \


### PR DESCRIPTION
This likely needs some revision. @dlongley mentioned that it should be decided if br-input-validation-error is even the proper name.  The display column is set to the same as the help, perhaps it needs its own styling?