### PR TITLE
Add validation by default to br-input.

### DIFF
--- a/input-directive.html
+++ b/input-directive.html
@@ -17,6 +17,11 @@
     <div ng-transclude="br-input-help"></div>
   </br-form-control-help>
   <br-form-control-validation-errors ng-if="brInputCtrl.options.showValidation">
-    <div ng-transclude="br-input-validation-errors"></div>
+    <!-- FIXME Validation errors may display weirdly for inline inputs. -->
+    <div ng-transclude="br-input-validation-errors">
+      <br-input-validation-errors>
+        An error was detected in the input above.
+      </br-input-validation-errors>
+    </div>
   </br-form-control-validation-errors>
 </br-form-control>

--- a/input-directive.html
+++ b/input-directive.html
@@ -19,9 +19,7 @@
   <br-form-control-validation-errors ng-if="brInputCtrl.options.showValidation">
     <!-- FIXME Validation errors may display weirdly for inline inputs. -->
     <div ng-transclude="br-input-validation-errors">
-      <br-input-validation-errors>
-        An error was detected in the input above.
-      </br-input-validation-errors>
+      An error was detected in the input above.
     </div>
   </br-form-control-validation-errors>
 </br-form-control>

--- a/input-directive.js
+++ b/input-directive.js
@@ -103,6 +103,10 @@ function Ctrl($attrs, $scope) {
     options = options || {};
     options.placeholder = options.placeholder || '';
 
+    if(!('showValidation' in options)) {
+      options.showValidation = true;
+    }
+
     // prefix "fa-" to icon
     if(typeof options.icon === 'string' &&
       options.icon.indexOf('fa-') !== 0) {


### PR DESCRIPTION
In relation to: https://github.com/digitalbazaar/bedrock-angular-form/issues/12

This adds validation by default to `br-input` -- validation can be turned of passing the `showValidation: false` option, and the default validation message can be overridden by transcluding your own `<br-input-validation-errors>` element.