### PR TITLE
Implement sameAs validator.

### DIFF
--- a/form.js
+++ b/form.js
@@ -21,7 +21,8 @@ define([
   './radio-group-directive',
   './select-component',
   './textarea-directive',
-  './track-state-directive'
+  './track-state-directive',
+  './validator-same-as-directive'
 ], function(
   angular,
   datepickerDirective,
@@ -38,7 +39,9 @@ define([
   radioGroupDirective,
   selectComponent,
   textareaDirective,
-  trackStateDirective) {
+  trackStateDirective,
+  validatorSameAs
+) {
 
 'use strict';
 
@@ -47,6 +50,7 @@ var module = angular.module('bedrock.form', ['bedrock.lazyCompile']);
 formControlComponent(module);
 selectComponent(module);
 inputDirective(module);
+validatorSameAs(module);
 
 module.directive(datepickerDirective);
 module.directive(formDirective);

--- a/validator-same-as-directive.js
+++ b/validator-same-as-directive.js
@@ -1,0 +1,36 @@
+/*!
+ * Copyright (c) 2016 Digital Bazaar, Inc. All rights reserved.
+ */
+define([], function() {
+
+'use strict';
+
+function register(module) {
+  module.directive('brValidatorSameAs', factory);
+}
+
+/* @ngInject */
+function factory() {
+  return {
+    restrict: 'A',
+    require: 'ngModel',
+    scope: {
+      sameAs: '<brValidatorSameAs'
+    },
+    link: Link
+  };
+
+  function Link(scope, element, attrs, ctrl) {
+    scope.$watch('sameAs', function() {
+      ctrl.$validate();
+    });
+
+    ctrl.$validators.brValidatorSameAs = function(modelValue) {
+      return scope.sameAs === modelValue;
+    };
+  }
+}
+
+return register;
+
+});


### PR DESCRIPTION
This is in response to: https://github.com/digitalbazaar/bedrock-angular-authn-password/issues/4

I'm not sure exactly why or how a validator like this would be implemented as an Angular component, but I believe using `$validators` as implemented here is the proper approach.

Example implementation: https://github.com/digitalbazaar/bedrock-idp/blob/passwordValidator/components/identity/create-identity-component.html#L99-L119