### PR TITLE
Evaluate `brOptions` in the context of the parent scope.

### DIFF
--- a/form-control-component.js
+++ b/form-control-component.js
@@ -52,8 +52,8 @@ function Ctrl($attrs, $element, $scope, $timeout) {
 
   self.$postLink = function() {
     $attrs.$observe('brOptions', function() {
-      self.options = self.defaultOptions($scope.$eval($attrs.brOptions ||
-        {}));
+      self.options = self.defaultOptions(
+        $scope.$parent.$eval($attrs.brOptions || {}));
       var labelWords = (self.options.label || '').split(' ');
       self.firstLabelWord = labelWords[0] || '';
       labelWords.shift();

--- a/form-group-directive.js
+++ b/form-group-directive.js
@@ -54,9 +54,9 @@ export default function factory(
           element.append(linked);
 
           attrs.brOptions = attrs.brOptions || {};
-          scope.options = scope.$eval(attrs.brOptions) || {};
+          scope.options = scope.$parent.$eval(attrs.brOptions) || {};
           attrs.$observe('brOptions', function(value) {
-            var options = scope.options = scope.$eval(value) || {};
+            var options = scope.options = scope.$parent.$eval(value) || {};
             // TODO: grab vocab via identifier from options
             // TODO: use repeater in template to pass options to
             // br-form-field(s)

--- a/input-directive.js
+++ b/input-directive.js
@@ -91,7 +91,7 @@ function Ctrl($attrs, $scope) {
 
   function legacyEval(expression) {
     // strip double parentheses
-    return $scope.$eval(fixLegacyExpression(expression));
+    return $scope.$parent.$eval(fixLegacyExpression(expression));
   }
 
   function defaultOptions(options) {

--- a/select-component.js
+++ b/select-component.js
@@ -195,7 +195,7 @@ function Ctrl($attrs, $element, $scope, $timeout, $transclude) {
 
   function legacyEval(expression) {
     // strip double parentheses
-    return $scope.$eval(expression.replace(/{{|}}/g, ''));
+    return $scope.$parent.$eval(expression.replace(/{{|}}/g, ''));
   }
 
   function defaultOptions(options) {

--- a/textarea-directive.js
+++ b/textarea-directive.js
@@ -85,7 +85,7 @@ function Ctrl($attrs, $scope) {
 
   function legacyEval(expression) {
     // strip double parentheses
-    return $scope.$eval(expression.replace(/{{|}}/g, ''));
+    return $scope.$parent.$eval(expression.replace(/{{|}}/g, ''));
   }
 
   function defaultOptions(options) {


### PR DESCRIPTION
This fixes a bug where br-options was being evaluated in the context of the scope of the directive or component itself rather than its parent. This seems to be the quickest fix for situations where dynamically generated components (with isolate scopes) need to use variables in their br-options expressions, particular within ng-repeats.